### PR TITLE
add :require-macros to core

### DIFF
--- a/src/qlkit_renderer/core.cljc
+++ b/src/qlkit_renderer/core.cljc
@@ -1,4 +1,5 @@
 (ns qlkit-renderer.core
+  #?(:cljs (:require-macros [qlkit-renderer.core]))
   (:require #?@(:cljs [[react-dom :refer [render]]
                        [react :refer [createElement]]
                        [create-react-class :refer [createReactClass]]])


### PR DESCRIPTION
this makes it possible to 

```
(require '[qlkit-renderer.core :as qr])
(qr/defcomponent ...)
```

without doing :refer-macros