### PR TITLE
Added support for WebComponents

### DIFF
--- a/src/qlkit_renderer/core.cljc
+++ b/src/qlkit_renderer/core.cljc
@@ -76,6 +76,8 @@
              (defn- ensure-element-type [typ]
                (or (cond (keyword? typ) (or (@ql/component-registry typ)
                                             (when (dom/valid-dom-elements typ)
+                                              (name typ))
+                                            (when (js/customElements.get (name typ))
                                               (name typ)))
                          (string? typ)  (when (dom/valid-dom-elements (keyword typ))
                                           typ))


### PR DESCRIPTION
This enables to use elements that are not Qlkit components nor known DOM elements, but registered customElements.